### PR TITLE
Skip the load_site before filter on the site admin page, so that you can 

### DIFF
--- a/app/controllers/admin/sites_controller.rb
+++ b/app/controllers/admin/sites_controller.rb
@@ -1,6 +1,8 @@
 class Admin::SitesController < Admin::BaseController
   helper :refinery_settings
 
+  skip_filter :load_site
+
   crudify :site,
           :title_attribute => :name,
           :order => "name ASC",


### PR DESCRIPTION
Skip the load_site before filter on the site admin page, so that you can edit sites.

Without this commit, you get an error whenever the site you want to edit doesn't match the one you're visiting, if the site doesn't have a recognized hostname, or you always end up editing the current site, regardless of the one you click "edit" on.

It would probably be better to have an authorization rule (with CanCan or something) to determine whether you can edit all sites, the one you're a member of, or none, but I "don't need it yet", so I'm punting on that.
