### PR TITLE
Modularize Site model

### DIFF
--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -1,15 +1,3 @@
 class Site < ActiveRecord::Base
-  belongs_to :page
-  attr_accessible :name, :page_id, :stylesheet, :hostnames,
-                  :hostnames_attributes
-
-  has_many :hostnames,
-           :dependent => :destroy
-
-  accepts_nested_attributes_for :hostnames, :allow_destroy => true
-
-  def self.find_by_hostname(hostname)
-    Site.joins(:hostnames).where(:hostnames=>{:hostname=>hostname}).first ||
-            Site.joins(:hostnames).where(:hostnames=>{:hostname=>'*'}).first
-  end
+  include Refinery::SiteModel
 end

--- a/lib/refinerycms-multisite.rb
+++ b/lib/refinerycms-multisite.rb
@@ -25,6 +25,9 @@ module Refinery
 
     included do
       belongs_to :page
+      attr_accessible :name, :page_id, :stylesheet, :hostnames,
+          :hostnames_attributes
+
       has_many :hostnames, :dependent => :destroy
 
       accepts_nested_attributes_for :hostnames, :allow_destroy => true

--- a/lib/refinerycms-multisite.rb
+++ b/lib/refinerycms-multisite.rb
@@ -19,6 +19,32 @@ module Refinery
       end
     end
   end
+
+  module SiteModel
+    extend ActiveSupport::Concern
+
+    included do
+      belongs_to :page
+      has_many :hostnames, :dependent => :destroy
+
+      accepts_nested_attributes_for :hostnames, :allow_destroy => true
+    end
+
+    module ClassMethods
+      def find_by_hostname(hostname)
+        Site.joins(:hostnames).where(:hostnames=>{:hostname=>hostname}).first ||
+          Site.joins(:hostnames).where(:hostnames=>{:hostname=>'*'}).first
+      end
+    end
+
+    module InstanceMethods
+    end
+  end
+  
+  module SiteModelClassMethods
+    #include ActiveRecord
+
+  end
 end
 
 module PagesControllerSite


### PR DESCRIPTION
We have an existing site model in our app, which has some customizations not present in your Site model. If we use refinerycms-multisite, our app/models/site.rb takes precedence. However, with this change, our Site model can include your relations by with the help of `include Refinery::SiteModel`.

Not 100% sure this is the best naming convention, but it does the trick for now; feel free to make it match your expectations.

As before, I haven't been nice enough to include tests. I can say it appears to work for my client's project, though.

I considered adding a more friendly method name that would do the including (in the style of devise) but that seemed unnecessary at this point.
